### PR TITLE
Add multi-agent experiment design

### DIFF
--- a/client/src/DAL/constants.ts
+++ b/client/src/DAL/constants.ts
@@ -1,4 +1,4 @@
-import { AbAgentsType, AgentType, FormType } from '@models/AppModels';
+import { AbAgentsType, AgentType, FormType, MultiAgentsType } from '@models/AppModels';
 
 export const defaultSliderSettings = {
     temperature: 1,
@@ -34,12 +34,15 @@ export const defaultAbAgents: AbAgentsType = {
     distB: 50,
 } as const;
 
+export const defaultMultiAgents: MultiAgentsType = [];
+
 export const defaultExperiment = {
     title: '',
     description: '',
     agentsMode: 'Single',
     activeAgent: null,
     abAgents: null,
+    multiAgents: defaultMultiAgents,
     isActive: true,
     maxMessages: undefined,
     maxConversations: undefined,

--- a/client/src/models/AppModels.ts
+++ b/client/src/models/AppModels.ts
@@ -80,9 +80,17 @@ export type AbAgentsType = {
     distB: number;
 };
 
+export type MultiAgentType = {
+    agent: string;
+    dist: number;
+};
+
+export type MultiAgentsType = MultiAgentType[];
+
 export const AgentsModes = {
     SINGLE: 'Single',
     AB: 'A/B',
+    MULTI: 'Multi',
 } as const;
 
 export interface DisplaySettings {
@@ -95,6 +103,7 @@ export interface ExperimentType {
     agentsMode: string;
     activeAgent: string;
     abAgents: AbAgentsType;
+    multiAgents: MultiAgentsType;
     createdAt: Date;
     timestamp: number;
     welcomeText: string;

--- a/client/src/screens/Admin/components/agents-panel/active-agents/MultiAgents.tsx
+++ b/client/src/screens/Admin/components/agents-panel/active-agents/MultiAgents.tsx
@@ -1,0 +1,101 @@
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import { AgentType } from '@models/AppModels';
+import {
+    Box,
+    Button,
+    FormControl,
+    IconButton,
+    MenuItem,
+    Select,
+    Typography,
+    TextField,
+} from '@mui/material';
+import { Controller, FieldErrors, useFieldArray } from 'react-hook-form';
+import { getFormErrorMessage } from '../../../../../utils/commonFunctions';
+
+interface MultiAgentsFormData {
+    multiAgents: { agent: string; dist: number }[];
+}
+
+interface MultiAgentsProps {
+    agents: AgentType[];
+    control: any;
+    register: any;
+    watch: any;
+    errors: FieldErrors<MultiAgentsFormData>;
+}
+
+const MultiAgents: React.FC<MultiAgentsProps> = ({ agents, control, register, watch, errors }) => {
+    const { fields, append, remove } = useFieldArray<{
+        multiAgents: { agent: string; dist: number }[];
+    }>({
+        control,
+        name: 'multiAgents',
+    });
+
+    const total = watch('multiAgents')?.reduce((sum, item) => sum + Number(item.dist || 0), 0) || 0;
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {fields.map((field, index) => (
+                <FormControl
+                    key={field.id}
+                    margin="dense"
+                    size="small"
+                    sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 1 }}
+                >
+                    <Typography>{`Agent ${index + 1}:`}</Typography>
+                    <Controller
+                        name={`multiAgents.${index}.agent`}
+                        control={control}
+                        defaultValue={field.agent || (agents[0]?._id || '')}
+                        rules={{ required: 'Agent is required.' }}
+                        render={({ field }) => (
+                            <Select {...field} size="small" style={{ minWidth: '100px' }}>
+                                {agents.map((agent) => (
+                                    <MenuItem key={agent._id} value={agent._id}>
+                                        {agent.title}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        )}
+                    />
+                    {errors.multiAgents?.[index]?.agent && (
+                        <Typography color="error">
+                            {getFormErrorMessage(errors.multiAgents[index].agent)}
+                        </Typography>
+                    )}
+                    <TextField
+                        type="number"
+                        size="small"
+                        sx={{ width: '60px' }}
+                        defaultValue={field.dist || 0}
+                        {...register(`multiAgents.${index}.dist`, { required: 'Distribution is required.' })}
+                    />
+                    {fields.length > 1 && (
+                        <IconButton onClick={() => remove(index)} size="small">
+                            <DeleteIcon />
+                        </IconButton>
+                    )}
+                </FormControl>
+            ))}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => append({ agent: agents[0]?._id || '', dist: 0 })}
+                    startIcon={<AddIcon />}
+                >
+                    Add Agent
+                </Button>
+                <Typography color={total === 100 ? 'inherit' : 'error'}>{`Total: ${total}%`}</Typography>
+            </Box>
+            {total !== 100 && (
+                <Typography color="error">Total distribution must equal 100%</Typography>
+            )}
+        </Box>
+    );
+};
+
+export default MultiAgents;

--- a/client/src/screens/Admin/components/experiments-panel/ExperimentForm.tsx
+++ b/client/src/screens/Admin/components/experiments-panel/ExperimentForm.tsx
@@ -18,6 +18,7 @@ import { Controller, useForm } from 'react-hook-form';
 import StyledSelection from '../../../../components/common/StyledSelection';
 import { getFormErrorMessage } from '../../../../utils/commonFunctions';
 import { AbAgents } from '../agents-panel/active-agents/AbAgents';
+import MultiAgents from '../agents-panel/active-agents/MultiAgents';
 import { MainContainer, SaveButton } from '../agents-panel/agent-form/AgentForm.s';
 
 const ExperimentForm = ({
@@ -55,10 +56,15 @@ const ExperimentForm = ({
     const handleSave = async (data) => {
         setIsSaveLoading(true);
         try {
-            if (data.agentsMode === 'Single') {
+            if (data.agentsMode === AgentsModes.SINGLE) {
                 data.abAgents = null;
+                data.multiAgents = null;
+            } else if (data.agentsMode === AgentsModes.AB) {
+                data.activeAgent = null;
+                data.multiAgents = null;
             } else {
                 data.activeAgent = null;
+                data.abAgents = null;
             }
             const parsedExperiment = {
                 ...data,
@@ -66,6 +72,7 @@ const ExperimentForm = ({
                 maxMessages: !data.maxMessages ? null : Number(data.maxMessages),
                 maxConversations: !data.maxConversations ? null : Number(data.maxConversations),
                 maxParticipants: !data.maxParticipants ? null : Number(data.maxParticipants),
+                multiAgents: data.multiAgents?.map((a) => ({ agent: a.agent.toString(), dist: Number(a.dist) })),
                 isActive: data.isActive,
             };
             if (!isEditMode) {
@@ -133,7 +140,11 @@ const ExperimentForm = ({
                         <Select {...field} labelId="agent-mode-select-label" style={{ minWidth: '100px' }}>
                             {Object.values(AgentsModes).map((mode) => (
                                 <MenuItem key={mode} value={mode}>
-                                    {mode === AgentsModes.SINGLE ? 'Single Condition' : AgentsModes.AB}
+                                    {mode === AgentsModes.SINGLE
+                                        ? 'Single Condition'
+                                        : mode === AgentsModes.AB
+                                        ? AgentsModes.AB
+                                        : AgentsModes.MULTI}
                                 </MenuItem>
                             ))}
                         </Select>
@@ -166,8 +177,10 @@ const ExperimentForm = ({
                         <Typography color="error">{getFormErrorMessage(errors.activeAgent)}</Typography>
                     )}
                 </FormControl>
-            ) : (
+            ) : agentsMode === AgentsModes.AB ? (
                 <AbAgents agents={agents} control={control} setValue={setValue} isRow={false} errors={errors} />
+            ) : (
+                <MultiAgents agents={agents} control={control} register={register} errors={errors} watch={watch} />
             )}
             <Typography
                 style={{

--- a/client/src/screens/Admin/components/experiments-panel/experiment-row/ExperimentRow.tsx
+++ b/client/src/screens/Admin/components/experiments-panel/experiment-row/ExperimentRow.tsx
@@ -21,6 +21,7 @@ export const ExperimentRow: React.FC<ExperimentRowProps> = ({ row, onStatusChang
     const [experimentAgentDetails, setExperimentAgentDetails] = useState<{
         activeAgent: AgentLeanType | null;
         abAgents: { agentA: AgentLeanType; agentB: AgentLeanType } | null;
+        multiAgents: { agent: AgentLeanType; dist: number }[] | null;
     }>(null);
 
     const timeAgo = (timestamp: number) => {

--- a/server/src/models/ExperimentsModel.ts
+++ b/server/src/models/ExperimentsModel.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'mongoose';
 import { mongoDbProvider } from '../mongoDBProvider';
-import { ABAgents, IExperiment } from '../types';
+import { ABAgents, IExperiment, MultiAgent } from '../types';
 
 const AbAgentsSchema = new Schema<ABAgents>({
     distA: { type: Number, required: true },
@@ -9,11 +9,20 @@ const AbAgentsSchema = new Schema<ABAgents>({
     agentB: { type: String, required: true },
 });
 
+const MultiAgentSchema = new Schema<MultiAgent>(
+    {
+        agent: { type: String, required: true },
+        dist: { type: Number, required: true },
+    },
+    { _id: false },
+);
+
 export const experimentsSchema = new Schema<IExperiment>(
     {
         agentsMode: { type: String, required: true },
         activeAgent: { type: String },
         abAgents: { type: AbAgentsSchema },
+        multiAgents: { type: [MultiAgentSchema] },
         createdAt: { type: Date, default: Date.now },
         timestamp: { type: Number, default: () => Date.now() },
         displaySettings: { type: Object },

--- a/server/src/services/experiments.service.ts
+++ b/server/src/services/experiments.service.ts
@@ -89,12 +89,22 @@ class ExperimentsService {
         let agentId;
         if (experiment.agentsMode === AgentsMode.SINGLE) {
             agentId = experiment.activeAgent;
-        } else {
+        } else if (experiment.agentsMode === AgentsMode.AB) {
             const rand = Math.random() * 100;
             if (experiment.abAgents.distA >= rand) {
                 agentId = experiment.abAgents.agentA;
             } else {
                 agentId = experiment.abAgents.agentB;
+            }
+        } else {
+            const rand = Math.random() * 100;
+            let sum = 0;
+            for (const agent of experiment.multiAgents) {
+                sum += agent.dist;
+                if (rand <= sum) {
+                    agentId = agent.agent;
+                    break;
+                }
             }
         }
 
@@ -123,7 +133,12 @@ class ExperimentsService {
     async getAllExperimentsByAgentId(agentId: string): Promise<IExperimentLean[]> {
         const result = await ExperimentsModel.find(
             {
-                $or: [{ activeAgent: agentId }, { 'abAgents.agentA': agentId }, { 'abAgents.agentB': agentId }],
+                $or: [
+                    { activeAgent: agentId },
+                    { 'abAgents.agentA': agentId },
+                    { 'abAgents.agentB': agentId },
+                    { 'multiAgents.agent': agentId },
+                ],
             },
             { _id: 1, title: 1 },
         );

--- a/server/src/types/common.type.ts
+++ b/server/src/types/common.type.ts
@@ -1,9 +1,11 @@
 export enum AgentConfig {
     SINGLE = 1,
     AB = 2,
+    MULTI = 3,
 }
 
 export const AgentsMode = {
     SINGLE: 'Single',
     AB: 'A/B',
+    MULTI: 'Multi',
 } as const;

--- a/server/src/types/experiments.type.ts
+++ b/server/src/types/experiments.type.ts
@@ -7,6 +7,11 @@ export interface ABAgents {
     distB: number;
 }
 
+export interface MultiAgent {
+    agent: string;
+    dist: number;
+}
+
 export interface DisplaySettings {
     welcomeContent: string;
     welcomeHeader: string;
@@ -33,6 +38,7 @@ export interface IExperiment {
     agentsMode: string;
     activeAgent: string;
     abAgents: ABAgents;
+    multiAgents: MultiAgent[];
     createdAt: Date;
     timestamp: number;
     displaySettings: DisplaySettings;


### PR DESCRIPTION
## Summary
- add `MULTI` option for experiments and schema updates on server
- choose multi agents with percent distribution in experiment UI
- support multi agents in experiment details and agent selection logic
- fix MultiAgents form typing for build

## Testing
- `npm test --silent` in `client` *(no tests found)*
- `npm run build --silent` in `client`
- `npm test --silent` in `server` *(failed: Cannot find module './test.ts')*
- `npm run build --silent` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6885036f1b988326b6fcf57f4d6ff8e0