### PR TITLE
Fix base strategy personality handling

### DIFF
--- a/server/src/services/conversations.service.ts
+++ b/server/src/services/conversations.service.ts
@@ -162,20 +162,17 @@ class ConversationsService {
 
     if (isPreConversation) {
       const metadata = await this.getConversationMetadata(conversationId);
-      if (
-        metadata.conversationStrategy &&
-        metadata.conversationStrategy !== "none"
-      ) {
-        const human = computeBigFiveRawScores(data);
-        const llm =
+      const human = computeBigFiveRawScores(data);
+      const fields: any = { humanPersonality: human };
+
+      if (metadata.conversationStrategy && metadata.conversationStrategy !== "none") {
+        fields.llmPersonality =
           metadata.conversationStrategy === "mirroring"
             ? human
             : complementRawScores(human);
-        await this.updateConversationMetadata(conversationId, {
-          humanPersonality: human,
-          llmPersonality: llm,
-        });
       }
+
+      await this.updateConversationMetadata(conversationId, fields);
     }
 
     return res;

--- a/server/src/services/dataAggregation.service.ts
+++ b/server/src/services/dataAggregation.service.ts
@@ -271,22 +271,22 @@ class DataAggregationService {
                         agentTemplate: agent.condition.systemStarterPrompt,
                         conversationStrategy: conversation.metadata.conversationStrategy,
                         openness: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.openness * 10
+                            ? conversation.metadata.humanPersonality.openness
                             : undefined,
                         conscientiousness: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.conscientiousness * 10
+                            ? conversation.metadata.humanPersonality.conscientiousness
                             : undefined,
                         extraversion: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.extraversion * 10
+                            ? conversation.metadata.humanPersonality.extraversion
                             : undefined,
                         agreeableness: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.agreeableness * 10
+                            ? conversation.metadata.humanPersonality.agreeableness
                             : undefined,
                         neuroticism: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.neuroticism * 10
+                            ? conversation.metadata.humanPersonality.neuroticism
                             : undefined,
                         llmPersonality: conversation.metadata.llmPersonality
-                            ? `Openness: ${conversation.metadata.llmPersonality.openness * 10}, Conscientiousness: ${conversation.metadata.llmPersonality.conscientiousness * 10}, Extraversion: ${conversation.metadata.llmPersonality.extraversion * 10}, Agreeableness: ${conversation.metadata.llmPersonality.agreeableness * 10}, Neuroticism: ${conversation.metadata.llmPersonality.neuroticism * 10}`
+                            ? `Openness: ${conversation.metadata.llmPersonality.openness}, Conscientiousness: ${conversation.metadata.llmPersonality.conscientiousness}, Extraversion: ${conversation.metadata.llmPersonality.extraversion}, Agreeableness: ${conversation.metadata.llmPersonality.agreeableness}, Neuroticism: ${conversation.metadata.llmPersonality.neuroticism}`
                             : undefined,
                         surveySubmittedAt: conversation.metadata.postConversation?.submittedAt,
                         username: {


### PR DESCRIPTION
## Summary
- store human personality scores regardless of selected strategy
- keep raw 0-50 scores in Excel export without multiplying by 10

## Testing
- `npm test` *(fails: Cannot find module './test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_688561bcf32483268b97102617ceb837