### PR TITLE
Improve export fallback for base strategy

### DIFF
--- a/server/src/services/conversations.service.ts
+++ b/server/src/services/conversations.service.ts
@@ -162,20 +162,17 @@ class ConversationsService {
 
     if (isPreConversation) {
       const metadata = await this.getConversationMetadata(conversationId);
-      if (
-        metadata.conversationStrategy &&
-        metadata.conversationStrategy !== "none"
-      ) {
-        const human = computeBigFiveRawScores(data);
-        const llm =
+      const human = computeBigFiveRawScores(data);
+      const fields: any = { humanPersonality: human };
+
+      if (metadata.conversationStrategy && metadata.conversationStrategy !== "none") {
+        fields.llmPersonality =
           metadata.conversationStrategy === "mirroring"
             ? human
             : complementRawScores(human);
-        await this.updateConversationMetadata(conversationId, {
-          humanPersonality: human,
-          llmPersonality: llm,
-        });
       }
+
+      await this.updateConversationMetadata(conversationId, fields);
     }
 
     return res;

--- a/server/src/services/dataAggregation.service.ts
+++ b/server/src/services/dataAggregation.service.ts
@@ -2,6 +2,7 @@ import ExcelJS from 'exceljs';
 import { conversationsService } from './conversations.service';
 import { experimentsService } from './experiments.service';
 import { usersService } from './users.service';
+import { computeBigFiveRawScores } from '../utils/bigFive';
 
 const mainSheetCol = [
     { header: 'Agents Mode', key: 'agentsMode' },
@@ -261,6 +262,14 @@ class DataAggregationService {
 
                 usersSheet.addRow(userRow);
                 user.conversations.forEach((conversation) => {
+                    const human =
+                        conversation.metadata.humanPersonality ||
+                        (conversation.metadata.preConversation
+                            ? computeBigFiveRawScores(
+                                  conversation.metadata.preConversation as any
+                              )
+                            : undefined);
+
                     const conversationRow = {
                         id: conversation.metadata._id,
                         userId: conversation.metadata.userId,
@@ -270,23 +279,13 @@ class DataAggregationService {
                         },
                         agentTemplate: agent.condition.systemStarterPrompt,
                         conversationStrategy: conversation.metadata.conversationStrategy,
-                        openness: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.openness * 10
-                            : undefined,
-                        conscientiousness: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.conscientiousness * 10
-                            : undefined,
-                        extraversion: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.extraversion * 10
-                            : undefined,
-                        agreeableness: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.agreeableness * 10
-                            : undefined,
-                        neuroticism: conversation.metadata.humanPersonality
-                            ? conversation.metadata.humanPersonality.neuroticism * 10
-                            : undefined,
+                        openness: human?.openness,
+                        conscientiousness: human?.conscientiousness,
+                        extraversion: human?.extraversion,
+                        agreeableness: human?.agreeableness,
+                        neuroticism: human?.neuroticism,
                         llmPersonality: conversation.metadata.llmPersonality
-                            ? `Openness: ${conversation.metadata.llmPersonality.openness * 10}, Conscientiousness: ${conversation.metadata.llmPersonality.conscientiousness * 10}, Extraversion: ${conversation.metadata.llmPersonality.extraversion * 10}, Agreeableness: ${conversation.metadata.llmPersonality.agreeableness * 10}, Neuroticism: ${conversation.metadata.llmPersonality.neuroticism * 10}`
+                            ? `Openness: ${conversation.metadata.llmPersonality.openness}, Conscientiousness: ${conversation.metadata.llmPersonality.conscientiousness}, Extraversion: ${conversation.metadata.llmPersonality.extraversion}, Agreeableness: ${conversation.metadata.llmPersonality.agreeableness}, Neuroticism: ${conversation.metadata.llmPersonality.neuroticism}`
                             : undefined,
                         surveySubmittedAt: conversation.metadata.postConversation?.submittedAt,
                         username: {


### PR DESCRIPTION
## Summary
- compute raw Big Five scores if conversation lacks personality data
- import `computeBigFiveRawScores` in the aggregation service

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_688561bcf32483268b97102617ceb837