### PR TITLE
Handle custom status codes

### DIFF
--- a/server/src/utils/requestHandler.ts
+++ b/server/src/utils/requestHandler.ts
@@ -4,11 +4,16 @@ export const requestHandler = (fn, onError?) => async (req, res) => {
         await fn(req, res);
         console.info(`Success request: ${req.method} ${req.originalUrl}`);
     } catch (error) {
-        console.error(`Error occurred in request: ${req.method} ${req.originalUrl}`, error);
+        console.error(
+            `Error occurred in request: ${req.method} ${req.originalUrl}`,
+            error,
+        );
         if (onError) {
             onError(req, res, error);
         } else {
-            res.status(500).json('Internal Server Error');
+            const statusCode = error?.status || 500;
+            const message = error?.message || 'Internal Server Error';
+            res.status(statusCode).json({ message });
         }
     }
 };


### PR DESCRIPTION
## Summary
- ensure server requestHandler passes through the error's custom status and message

## Testing
- `npm test --prefix server`
- `npm test --prefix client -- -w=1`


------
https://chatgpt.com/codex/tasks/task_e_6888f66f13988326802cac3ea82432d9