### PR TITLE
Use personality prompt as system prompt for mirroring/complementing

### DIFF
--- a/server/src/services/conversations.service.ts
+++ b/server/src/services/conversations.service.ts
@@ -275,11 +275,10 @@ class ConversationsService {
     message: Message,
     metadata?: IMetadataConversation
   ) => {
-    const systemPrompt = { role: "system", content: agent.systemStarterPrompt };
-    const personalityPrompt =
-      metadata?.conversationStrategy && metadata.llmSystemPrompt
+    const systemPrompt =
+      metadata?.conversationStrategy && metadata.conversationStrategy !== "none"
         ? { role: "system", content: metadata.llmSystemPrompt }
-        : null;
+        : { role: "system", content: agent.systemStarterPrompt };
     const beforeUserMessage = {
       role: "system",
       content: agent.beforeUserSentencePrompt,
@@ -290,7 +289,6 @@ class ConversationsService {
     };
 
     const messages = [systemPrompt];
-    if (personalityPrompt) messages.push(personalityPrompt);
     messages.push(
       ...conversation,
       beforeUserMessage,


### PR DESCRIPTION
## Summary
- use the personality prompt as the first system message when a conversation strategy is active

## Testing
- `npm test --prefix server`
- `CI=true npm test --prefix client -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688a5092f59883269f5d0deaf69aae99